### PR TITLE
Fixes HHVM is no longer supported in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ env:
     - setup=basic
     - xdebug=true
 
+# HHVM is no longer supported on Ubuntu Precise. Please consider using Trusty with `dist: trusty`.
+dist: trusty
+
 cache:
   directories:
     - $HOME/.composer/cache


### PR DESCRIPTION
Fixes Travis HHVM Image: 

- HHVM is no longer supported on Ubuntu Precise. Please consider using Trusty with `dist: trusty`.